### PR TITLE
Add after-unveil event.

### DIFF
--- a/lazysizes.js
+++ b/lazysizes.js
@@ -259,6 +259,9 @@
 				updatePolyfill(elem, {srcset: srcset, src: src});
 			}
 		});
+
+		var event = triggerEvent(elem, 'lazyafterunveil');
+
 		return elem;
 	}
 


### PR DESCRIPTION
This added event allows one to bind to the completion of the image srcset being set, allowing for easy implementation of fade-in effects. 
