### PR TITLE
Make _lazyrias property writable

### DIFF
--- a/plugins/rias/ls.rias.js
+++ b/plugins/rias/ls.rias.js
@@ -143,7 +143,8 @@
 
 		elem.setAttribute(config.srcsetAttr, src.srcset.join(', '));
 		Object.defineProperty(elem, '_lazyrias', {
-			value: src
+			value: src,
+			writable: true
 		});
 	}
 


### PR DESCRIPTION
Hi,

Because I update the data-src attribute dynamically (https://github.com/aFarkas/lazysizes/issues/46), the lazysizes calls the setSrc method more than one time for an element. In this case an error occurs in setSrc method when Object.defineProperty is called the second time. 

This pull requests makes the property  _lazyrias writable which allows to re-define the property again. Please let me know whether it's ok or whether it may break something else.

Best,
Alex