### PR TITLE
Fix typo in title

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head lang="en">
 	<meta charset="UTF-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
-	<title>lazysizes - the umltimate lazyloader for responsive images, iframes and widget</title>
+	<title>lazysizes - the ultimate lazyloader for responsive images, iframes and widget</title>
 	<link rel="canonical" href="http://afarkas.github.io/lazysizes/index.html" />
 
 	<!-- polyfill responsive images: https://github.com/aFarkas/respimage -->


### PR DESCRIPTION
The index.html file in gh-pages branch has a typo in the title ("umltimate" instead of "ultimate").