### PR TITLE
Aspect ratio plugin: fix JS error on resize

### DIFF
--- a/plugins/aspectratio/ls.aspectratio.js
+++ b/plugins/aspectratio/ls.aspectratio.js
@@ -3,6 +3,8 @@
 
 	if(!window.addEventListener){return;}
 
+  var forEach = Array.prototype.forEach;
+
 	var imageRatio, extend$, $;
 
 	var regPicture = /^picture$/i;
@@ -72,7 +74,7 @@
 			addEventListener('resize', (function(){
 				var timer;
 				var resize = function(){
-					Array.prototype.forEach.call(module.ratioElems, addRemoveAspectRatio);
+          forEach.call(module.ratioElems, addRemoveAspectRatio);
 				};
 
 				return function(){

--- a/plugins/aspectratio/ls.aspectratio.js
+++ b/plugins/aspectratio/ls.aspectratio.js
@@ -72,10 +72,7 @@
 			addEventListener('resize', (function(){
 				var timer;
 				var resize = function(){
-					var i, len;
-					for(i = 0, len = module.ratioElems.length; i < len; i++){
-						addRemoveAspectRatio(module.ratioElems[i]);
-					}
+          Array.prototype.forEach.call(module.ratioElems, addRemoveAspectRatio);
 				};
 
 				return function(){

--- a/plugins/aspectratio/ls.aspectratio.js
+++ b/plugins/aspectratio/ls.aspectratio.js
@@ -3,7 +3,7 @@
 
 	if(!window.addEventListener){return;}
 
-  var forEach = Array.prototype.forEach;
+	var forEach = Array.prototype.forEach;
 
 	var imageRatio, extend$, $;
 
@@ -74,7 +74,7 @@
 			addEventListener('resize', (function(){
 				var timer;
 				var resize = function(){
-          forEach.call(module.ratioElems, addRemoveAspectRatio);
+					forEach.call(module.ratioElems, addRemoveAspectRatio);
 				};
 
 				return function(){

--- a/plugins/aspectratio/ls.aspectratio.js
+++ b/plugins/aspectratio/ls.aspectratio.js
@@ -72,7 +72,7 @@
 			addEventListener('resize', (function(){
 				var timer;
 				var resize = function(){
-          Array.prototype.forEach.call(module.ratioElems, addRemoveAspectRatio);
+					Array.prototype.forEach.call(module.ratioElems, addRemoveAspectRatio);
 				};
 
 				return function(){


### PR DESCRIPTION
**Description**: 
There is a JS error on resize if Aspect ratio plugin is enabled - [Demo error](https://sergesemashko.github.io/lazysizes/test/broken-aspect-ratio/). After debugging I figured out that referenced in local scope `module.ratioElems` array has changed by something before loop ends. 

**Fix**:
I replaced loop by forEach as IE8 is not in supported browsers list. So, we make sure `addRemoveAspectRatio()` is called for existing in `module.ratioElems` array items. [Demo fix](https://sergesemashko.github.io/lazysizes/test/fixed-aspect-ratio/).

@aFarkas please review. Also, should I commit minified file?