### PR TITLE
Trigger event after image has loaded and loadedClass attached.

### DIFF
--- a/lazysizes.js
+++ b/lazysizes.js
@@ -304,6 +304,7 @@
 			addClass(e.target, lazySizesConfig.loadedClass);
 			removeClass(e.target, lazySizesConfig.loadingClass);
 			addRemoveLoadEvents(e.target, switchLoadingClass);
+			triggerEvent(e.target, 'lazyloaded');
 		};
 
 		var changeIframeSrc = function(elem, src){


### PR DESCRIPTION
We needed to have an event fire after the image has completely loaded in order to place elements based on actual image dimensions that were unknown before image had loaded.