### PR TITLE
allow ratio handling by element

### DIFF
--- a/plugins/bgset/ls.bgset.js
+++ b/plugins/bgset/ls.bgset.js
@@ -19,6 +19,7 @@
 	var createPicture = function(sets, elem, img){
 		var picture = document.createElement('picture');
 		var sizes = elem.getAttribute(lazySizesConfig.sizesAttr);
+		var ratio = elem.getAttribute('data-ratio');
 		var optimumx = elem.getAttribute('data-optimumx');
 		var bgSize = (getComputedStyle(elem) || {getPropertyValue: function(){}}).getPropertyValue('background-size');
 
@@ -75,6 +76,9 @@
 		}
 		if(optimumx){
 			img.setAttribute('data-optimumx', optimumx);
+		}
+		if(ratio) {
+			img.setAttribute('data-ratio', ratio);
 		}
 
 		picture.appendChild(img);

--- a/plugins/rias/ls.rias.js
+++ b/plugins/rias/ls.rias.js
@@ -147,20 +147,21 @@
 	}
 
 	function setSrc(src, opts, elem){
+		var elemW = 0, elemH = 0;
 
 		if(!src){return;}
 
 		if (opts.ratio === 'container') {
 			// calculate image or parent ratio
 			var sizeElement = elem;
-			var elemW = sizeElement.scrollWidth;
-			var elemH = sizeElement.scrollHeight;
-			while ((elemW === 0 || elemH === 0) && sizeElement !== document) {
+			elemW = sizeElement.scrollWidth;
+			elemH = sizeElement.scrollHeight;
+			while ((!elemW || !elemH) && sizeElement !== document) {
 				sizeElement = sizeElement.parentNode;
 				elemW = sizeElement.scrollWidth;
 				elemH = sizeElement.scrollHeight;
 			}
-			if (elemW !== 0 && elemH !== 0) {
+			if (elemW && elemH) {
 				opts.ratio = elemH / elemW;
 			}
 		}

--- a/plugins/rias/ls.rias.js
+++ b/plugins/rias/ls.rias.js
@@ -9,6 +9,7 @@
 	var regNumber = /^\-*\+*\d+\.*\d*$/;
 	var regPicture = /^picture$/i;
 	var regWidth = /\s*\{\s*width\s*\}\s*/i;
+	var regHeight = /\s*\{\s*height\s*\}\s*/i;
 	var regPlaceholder = /\s*\{\s*([a-z0-9]+)\s*\}\s*/ig;
 	var regObj = /^\[.*\]|\{.*\}$/;
 	var regAllowedSizes = /^(?:auto|\d+(px)?)$/;
@@ -26,7 +27,8 @@
 			srcAttr: 'data-src',
 			absUrl: false,
 			modifyOptions: noop,
-			widthmap: {}
+			widthmap: {},
+			ratio: false
 		};
 
 		config = (window.lazySizes && lazySizes.cfg) || window.lazySizesConfig;
@@ -131,8 +133,10 @@
 		url = ((options.prefix || '') + url + (options.postfix || '')).replace(regPlaceholder, replaceFn);
 
 		options.widths.forEach(function(width){
+			width = options.widthmap[width] || width;
 			var candidate = {
-				u: url.replace(regWidth, options.widthmap[width] || width),
+				u: url.replace(regWidth, width)
+						.replace(regHeight, options.ratio ? Math.round(width * options.ratio) : ''),
 				w: width
 			};
 
@@ -145,6 +149,21 @@
 	function setSrc(src, opts, elem){
 
 		if(!src){return;}
+
+		if (opts.ratio === 'container') {
+			// calculate image or parent ratio
+			var sizeElement = elem;
+			var elemW = sizeElement.scrollWidth;
+			var elemH = sizeElement.scrollHeight;
+			while ((elemW === 0 || elemH === 0) && sizeElement !== document) {
+				sizeElement = sizeElement.parentNode;
+				elemW = sizeElement.scrollWidth;
+				elemH = sizeElement.scrollHeight;
+			}
+			if (elemW !== 0 && elemH !== 0) {
+				opts.ratio = elemH / elemW;
+			}
+		}
 
 		src = replaceUrlProps(src, opts);
 


### PR DESCRIPTION
Handling the ratio allows you to add the {height} replacement in the images url.
Also, this is specially useful when some smart cropping service is available (like https://github.com/thumbor/thumbor).

* If the data-ratio is not set, this replace the {height} by empty (This maintains the current behavior).
* If the data-ratio is set to a number, the {height} is replace by the proportional height according to the ratio specified.
* if the data-ratio is set to the word "container", the ratio is automatically calculated based on the container size and the {height} is replaced accordingly.

FYI: the bgset plugin clones the attributes, so I added de data-ratio to be cloned also.