### PR TITLE
Add the main key so it can be required with Browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "url": "git://github.com/aFarkas/lazysizes.git"
   },
   "namespace": "lazySizes",
+  "main": "lazysizes.js",
   "browser": "lazysizes.js",
   "devDependencies": {
     "grunt": "~0.4.2",
@@ -54,7 +55,7 @@
     "respimage",
     "include",
     "ajax",
-    "img",
+    "img",m
     "imager",
     "imager.js",
     "picturefill",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "respimage",
     "include",
     "ajax",
-    "img",m
+    "img",
     "imager",
     "imager.js",
     "picturefill",


### PR DESCRIPTION
I want to use lazysizes with Browserify. This resolves the issue that says "Uncaught Error: Cannot find module 'lazysizes'".