### PR TITLE
Configuration from CSS variables

### DIFF
--- a/plugins/rias/ls.rias.js
+++ b/plugins/rias/ls.rias.js
@@ -83,8 +83,7 @@
 		};
 
 		setOption = function(attr, run){
-			var attrVal = elem.getAttribute('data-'+ attr);
-			attrVal = elemStyles.getPropertyValue('--' + attr).trim() || attrVal;
+			var attrVal = elem.getAttribute('data-'+ attr) || elemStyles.getPropertyValue('--ls-' + attr).trim() || null;
 
 			if(attrVal != null){
 				if(attrVal == 'true'){

--- a/plugins/rias/ls.rias.js
+++ b/plugins/rias/ls.rias.js
@@ -74,6 +74,7 @@
 
 	function getElementOptions(elem, src){
 		var attr, parent, setOption, options;
+		var elemStyles = window.getComputedStyle(elem);
 
 
 		parent = elem.parentNode;
@@ -83,6 +84,7 @@
 
 		setOption = function(attr, run){
 			var attrVal = elem.getAttribute('data-'+ attr);
+			attrVal = elemStyles.getPropertyValue('--' + attr).trim() || attrVal;
 
 			if(attrVal != null){
 				if(attrVal == 'true'){
@@ -114,12 +116,6 @@
 				setOption(match, true);
 			}
 		});
-
-		var elemStyles = window.getComputedStyle(elem);
-		var aspectRatio = elemStyles.getPropertyValue('--aspect-ratio').trim() || null;
-                if (aspectRatio) {
-                    options.ratio = aspectRatio;
-                }
 
 		return options;
 	}

--- a/plugins/rias/ls.rias.js
+++ b/plugins/rias/ls.rias.js
@@ -115,6 +115,12 @@
 			}
 		});
 
+		var elemStyles = window.getComputedStyle(elem);
+		var aspectRatio = elemStyles.getPropertyValue('--aspect-ratio').trim() || null;
+                if (aspectRatio) {
+                    options.ratio = aspectRatio;
+                }
+
 		return options;
 	}
 

--- a/rias/index.html
+++ b/rias/index.html
@@ -36,10 +36,10 @@
 		}
 
 		.tall img {
-			--aspect-ratio: 2
+			--ratio: 2
 		}
 		.wide img {
-			--aspect-ratio: 0.5
+			--ratio: 0.5;
 		}
 	</style>
 

--- a/rias/index.html
+++ b/rias/index.html
@@ -35,6 +35,12 @@
 			tab-size: 2;
 		}
 
+		.tall img {
+			--aspect-ratio: 2
+		}
+		.wide img {
+			--aspect-ratio: 0.5
+		}
 	</style>
 
 	<script>
@@ -89,6 +95,52 @@
 	class="lazyload"
 	alt="" /&gt;
 </pre>
+			</div>
+		</div>
+
+		<div class="row">
+			<div class="col-sm-6">
+				<div class="thumbnail">
+					<div class="tall">
+						<img
+							 src="http://placehold.it/100x100"
+							 data-src="http://placehold.it/{width}x{height}"
+							 data-sizes="auto"
+							 class="lazyload"
+							 alt="" />
+					</div>
+				</div>
+			</div>
+			<div class="col-sm-6">
+				<div class="thumbnail">
+					<div class="wide">
+						<img
+							 src="http://placehold.it/200x100"
+							 data-src="http://placehold.it/{width}x{height}"
+							 data-sizes="auto"
+							 class="lazyload"
+							 alt="" />
+					</div>
+				</div>
+			</div>
+			<div class="col-sm-6">
+				<h3>Aspect ratio</h3>
+				<p>In addition, you can set the ascpect ratio of the image from CSS. You only need to set the custom CSS variable <code>--aspect-ratio</code> on the <code>img</code> and add a <code>{height}</code> placeholder </p>
+<pre>
+&lt;style&gt;
+		img.rectangle {
+			--aspect-ratio: 0.5
+		}
+&lt;style/&gt;
+
+&lt;img
+	src="http://placehold.it/200x100"
+	data-src="http://placehold.it/{width}x{height}"
+	data-sizes="auto"
+	class="lazyload rectangle"
+	alt="" /&gt;
+</pre>
+			    <p>Note that you can also set the aspect ratio via a <code>data-ratio</code> value on the <code>img</code> tag.</p>
 			</div>
 		</div>
 

--- a/rias/index.html
+++ b/rias/index.html
@@ -36,10 +36,10 @@
 		}
 
 		.tall img {
-			--ratio: 2
+			--ls-ratio: 2
 		}
 		.wide img {
-			--ratio: 0.5;
+			--ls-ratio: 0.5;
 		}
 	</style>
 
@@ -125,11 +125,11 @@
 			</div>
 			<div class="col-sm-6">
 				<h3>Aspect ratio</h3>
-				<p>In addition, you can set the ascpect ratio of the image from CSS. You only need to set the custom CSS variable <code>--aspect-ratio</code> on the <code>img</code> and add a <code>{height}</code> placeholder </p>
+				<p>In addition, you can set the ascpect ratio of the image from CSS. You only need to set the custom CSS variable <code>--ls-ratio</code> on the <code>img</code> and add a <code>{height}</code> placeholder </p>
 <pre>
 &lt;style&gt;
 		img.rectangle {
-			--aspect-ratio: 0.5
+			--ls-ratio: 0.5
 		}
 &lt;style/&gt;
 


### PR DESCRIPTION
allow configuration provided by CSS to override configuration on the <img tag.

This is done in 2 patches, the first only implements this for aspect ratio, the second for all configuration items. I don't know what is preferred by the lazysizes developers.