### PR TITLE
Lazyloaded class added before image loaded. Only happen on firefox.

### DIFF
--- a/src/lazysizes-core.js
+++ b/src/lazysizes-core.js
@@ -448,7 +448,7 @@ function l(window, document) {
 			removeClass(elem, lazySizesConfig.lazyClass);
 
 			rAF(function(){
-				if( !firesLoad || elem.complete ){
+				if( !firesLoad || IsImageLoaded(elem) ){
 					if(firesLoad){
 						resetPreloading(event);
 					} else {
@@ -458,6 +458,26 @@ function l(window, document) {
 				}
 			}, true);
 		});
+
+		var IsImageLoaded = function(img) {
+			// During the onload event, IE correctly identifies any images that
+			// weren’t downloaded as not complete. Others should too. Gecko-based
+			// browsers act like NS4 in that they report this incorrectly.
+			if (!img.complete) {
+				return false;
+			}
+
+			// However, they do have two very useful properties: naturalWidth and
+			// naturalHeight. These give the true size of the image. If it failed
+			// to load, either of these should be zero.
+
+			if (typeof img.naturalWidth !== "undefined" && img.naturalWidth === 0) {
+				return false;
+			}
+
+			// No other way of checking: assume it’s ok.
+			return true;
+		};
 
 		var unveilElement = function (elem){
 			var detail;


### PR DESCRIPTION
fix for #342 issues, tested and now its work on firefox
