### PR TITLE
Enable Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: node_js

--- a/package.json
+++ b/package.json
@@ -60,5 +60,8 @@
     "imager.js",
     "picturefill",
     "component"
-  ]
+  ],
+  "scripts": {
+  	"test": "grunt qunit"
+  }
 }


### PR DESCRIPTION
Using Travis CI is a good way to quickly tell if all tests are passing without the need to clone the repo and run the tests locally.