### PR TITLE
Recognize Opera Mini and let it load images

### DIFF
--- a/src/lazysizes-core.js
+++ b/src/lazysizes-core.js
@@ -235,7 +235,7 @@ function l(window, document) {
 		var regImg = /^img$/i;
 		var regIframe = /^iframe$/i;
 
-		var supportScroll = ('onscroll' in window) && !(/glebot/.test(navigator.userAgent));
+		var supportScroll = ('onscroll' in window) && !(/glebot/.test(navigator.userAgent)) && !('operamini' in window);
 
 		var shrinkExpand = 0;
 		var currentExpand = 0;


### PR DESCRIPTION
Presence of window.operamini object is used to detect Opera Mini
transcoders and load images the same way other non scrolling clients
get them.