### PR TITLE
Confirm isIntersecting property

### DIFF
--- a/src/lazysizes-intersection.js
+++ b/src/lazysizes-intersection.js
@@ -329,6 +329,9 @@
 		var unveilElements = function(change){
 			var i, len;
 			for(i = 0, len = change.length; i < len; i++){
+				if (change.isIntersecting === false) {
+					continue;
+				}
 				unveilElement(change[i].target);
 			}
 		};

--- a/src/lazysizes-intersection.js
+++ b/src/lazysizes-intersection.js
@@ -329,7 +329,7 @@
 		var unveilElements = function(change){
 			var i, len;
 			for(i = 0, len = change.length; i < len; i++){
-				if (change.isIntersecting === false) {
+				if (change[i].isIntersecting === false) {
 					continue;
 				}
 				unveilElement(change[i].target);


### PR DESCRIPTION
I found `IntersectionObserverEntry::isIntersecting` related issue.

Once element started to observe intersecting as `IntersectionObserver::observe(element)`, `IntersectionObserverCallback` is called immediately even if element has intersected or not, so lazyload request might be fired immediately.

To prevent it, I suggest to confirm `IntersectionObserverEntry::isIntersecting` property, it supplies element has intersected or not.

Spec: https://w3c.github.io/IntersectionObserver/#intersectionobserverentry

I investigated browsers support of this property:

- Chrome (greater than 58) supported, less versions returns `undefined`
- Firefox (greater than 55) supported
- Edge 15,16 supported
- Polyfill of https://github.com/jeremenichelli/intersection-observer-polyfill also supported

If that property didn't support, returns `undefined`, so it has to compare with `=== false`.

