### PR TITLE
Put transition property on right class

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,11 +179,11 @@ Please also have a look at our [lazysizes Blur Up plugin](https://jsfiddle.net/t
 	.fade-box .lazyload,
 	 .fade-box .lazyloading {
 		opacity: 0;
-		transition: opacity 400ms;
 	}
 
 	.fade-box img.lazyloaded {
 		opacity: 1;
+		transition: opacity 400ms;
 	}
 </style>
 


### PR DESCRIPTION
Transitioning only works if you put it on the `.lazyloaded` class.