### PR TITLE
Optimize handling of arguments exotic object

### DIFF
--- a/src/lazysizes-intersection.js
+++ b/src/lazysizes-intersection.js
@@ -103,10 +103,14 @@
 		};
 
 		return function(fn){
+			var args;
+
 			if(running){
 				fn.apply(this, arguments);
 			} else {
-				fns.push([fn, this, arguments]);
+				args = [];
+				args.push.apply(args, arguments)
+				fns.push([fn, this, args]);
 
 				if(!waiting){
 					waiting = true;
@@ -122,11 +126,7 @@
 				rAF(fn);
 			} :
 			function(){
-				var that = this;
-				var args = arguments;
-				rAF(function(){
-					fn.apply(that, args);
-				});
+				rAF(fn.bind.bind(fn, this).apply(undefined, arguments));
 			}
 		;
 	};


### PR DESCRIPTION
The `arguments` object is really finicky if you don't want to get deoptimized. This comes from it having special powers, like the ability to reassign parameters and checking `caller`/`callee`.

So JS engines tend to bail out on optimization if they detect any other use then a very restricted subset. That subset is:

1. Access `arguments.length`
2. Access by index, (`arguments[1]`), for index =< `arguments.length`
3. Calling `Function.prototype.apply` with `arguments` as the second argument. I.e. passing along all arguments to another function `fn.apply(this, arguments)`.

See https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#32-leaking-arguments