### PR TITLE
Resolve race condition with blurImg

### DIFF
--- a/plugins/blur-up/ls.blur-up.js
+++ b/plugins/blur-up/ls.blur-up.js
@@ -54,7 +54,9 @@
 
 				if(blurImg){
 					lazySizes.rAF(function () {
-						lazySizes.aC(blurImg, 'ls-blur-up-loaded');
+						if(blurImg) {
+							lazySizes.aC(blurImg, 'ls-blur-up-loaded');
+						}
 					});
 
 					blurImg.removeEventListener('load', onloadBlurUp);


### PR DESCRIPTION
blurImg can already be nulled out by the time the rAF function is called, so we have to check there as well.