### PR TITLE
Add an empty alt attribute to the blur up image 

### DIFF
--- a/plugins/blur-up/ls.blur-up.js
+++ b/plugins/blur-up/ls.blur-up.js
@@ -72,6 +72,7 @@
 			blurImg.className = 'ls-blur-up-img';
 			blurImg.src = src;
 			blurImg.alt = '';
+			blurImg.setAttribute('aria-hidden', 'true');
 
 			blurImg.className += ' ls-inview';
 

--- a/plugins/blur-up/ls.blur-up.js
+++ b/plugins/blur-up/ls.blur-up.js
@@ -71,6 +71,7 @@
 
 			blurImg.className = 'ls-blur-up-img';
 			blurImg.src = src;
+			blurImg.alt = '';
 
 			blurImg.className += ' ls-inview';
 


### PR DESCRIPTION
Add an empty alt attribute to the blur up plugin to satisfy a11y recommendations. [https://dequeuniversity.com/rules/axe/2.2/image-alt](url)

The Accessibility audit in Google Chrome reports the blur image as a failing element.