### PR TITLE
fix: for #597

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /play
 node_modules
 bower_components
+*.min.js

--- a/.npmignore
+++ b/.npmignore
@@ -21,4 +21,3 @@ Gruntfile.js
 component.json
 bower.json
 Authors.txt
-*.min.js


### PR DESCRIPTION
I assume it was intended to add *.min.js to the .gitignore rather than the .npmignore