### PR TITLE
Catch if some one has done something silly like passing in a string

### DIFF
--- a/plugins/rias/ls.rias.js
+++ b/plugins/rias/ls.rias.js
@@ -158,7 +158,9 @@
 		}
 
 		url = ((options.prefix || '') + url + (options.postfix || '')).replace(regPlaceholder, replaceFn);
-
+		
+		if (typeof options.widths === 'string') {options.widths = JSON.parse(options.widths);}
+		
 		options.widths.forEach(function(width){
 			var widthAlias = options.widthmap[width] || width;
 			var ratio = options.aspectratio || options.ratio;


### PR DESCRIPTION
As this is in use on multiple shopify themes, I noticed a few failures where by some one has referenced widths from a data attribute without parsing it. I haven't dived in deep to see the source of the issues, I will, however just thought a sanity check here or further up where the default config is referencing it may be a good idea :)