### PR TITLE
Fix issues with SSR builds by adding window bind and Date reference.

### DIFF
--- a/lazysizes-umd.js
+++ b/lazysizes-umd.js
@@ -1,5 +1,5 @@
 (function(window, factory) {
-	var lazySizes = factory(window, window.document);
+	var lazySizes = factory(window, window.document, Date);
 	if(typeof module == 'object' && module.exports){
 		module.exports = lazySizes;
 	} else if (typeof define == 'function' && define.amd) {
@@ -7,7 +7,7 @@
 	} else {
 		window.lazySizes = lazySizes;
 	}
-}(window, function l(window, document) {
+}(window, function l(window, document, Date) {
 	'use strict';
 	/*jshint eqnull:true */
 
@@ -58,15 +58,13 @@
 
 	var docElem = document.documentElement;
 
-	var Date = window.Date;
-
 	var supportPicture = window.HTMLPictureElement;
 
 	var _addEventListener = 'addEventListener';
 
 	var _getAttribute = 'getAttribute';
 
-	var addEventListener = window[_addEventListener];
+	var addEventListener = window[_addEventListener].bind(window);
 
 	var setTimeout = window.setTimeout;
 

--- a/lazysizes.js
+++ b/lazysizes.js
@@ -1,11 +1,11 @@
 (function(window, factory) {
-	var lazySizes = factory(window, window.document);
+	var lazySizes = factory(window, window.document, Date);
 	window.lazySizes = lazySizes;
 	if(typeof module == 'object' && module.exports){
 		module.exports = lazySizes;
 	}
 }(typeof window != 'undefined' ?
-      window : {}, function l(window, document) {
+      window : {}, function l(window, document, Date) {
 	'use strict';
 	/*jshint eqnull:true */
 
@@ -56,15 +56,13 @@
 
 	var docElem = document.documentElement;
 
-	var Date = window.Date;
-
 	var supportPicture = window.HTMLPictureElement;
 
 	var _addEventListener = 'addEventListener';
 
 	var _getAttribute = 'getAttribute';
 
-	var addEventListener = window[_addEventListener];
+	var addEventListener = window[_addEventListener].bind(window);
 
 	var setTimeout = window.setTimeout;
 

--- a/src/common.wrapper
+++ b/src/common.wrapper
@@ -1,5 +1,5 @@
 (function(window, factory) {
-	var lazySizes = factory(window, window.document);
+	var lazySizes = factory(window, window.document, Date);
 	window.lazySizes = lazySizes;
 	if(typeof module == 'object' && module.exports){
 		module.exports = lazySizes;

--- a/src/lazysizes-core.js
+++ b/src/lazysizes-core.js
@@ -1,4 +1,4 @@
-function l(window, document) {
+function l(window, document, Date) { // Pass in the windoe Date function also for SSR because the Date class can be lost
 	'use strict';
 	/*jshint eqnull:true */
 
@@ -49,15 +49,17 @@ function l(window, document) {
 
 	var docElem = document.documentElement;
 
-	var Date = window.Date;
-
 	var supportPicture = window.HTMLPictureElement;
 
 	var _addEventListener = 'addEventListener';
 
 	var _getAttribute = 'getAttribute';
 
-	var addEventListener = window[_addEventListener];
+	/**
+	 * Update to bind to window because 'this' becomes null during SSR
+	 * builds.
+	 */
+	var addEventListener = window[_addEventListener].bind(window);
 
 	var setTimeout = window.setTimeout;
 

--- a/src/lazysizes-intersection.js
+++ b/src/lazysizes-intersection.js
@@ -2,9 +2,9 @@
 	if(typeof module == 'object' && module.exports){
 		module.exports = lazySizes;
 	} else {
-		window.lazySizes = factory(window, window.document);
+		window.lazySizes = factory(window, window.document, Date);
 	}
-}(window, function l(window, document) {
+}(window, function l(window, document, Date) {
 	'use strict';
 
 	/*jshint eqnull:true */
@@ -14,15 +14,13 @@
 
 	var docElem = document.documentElement;
 
-	var Date = window.Date;
-
 	var supportPicture = window.HTMLPictureElement;
 
 	var _addEventListener = 'addEventListener';
 
 	var _getAttribute = 'getAttribute';
 
-	var addEventListener = window[_addEventListener];
+	var addEventListener = window[_addEventListener].bind(window);
 
 	var setTimeout = window.setTimeout;
 


### PR DESCRIPTION
Running an SSR build with this lib in Angular produces

```
/.../dist/server.js:353
                        throw error;
                        ^

TypeError: Cannot read property '_listeners' of undefined
    at addEventListener (/.../dist/server.js:95761:15)
    at Object._ (/.../dist/server.js:183273:5)
    at init (/.../dist/server.js:183283:14)
    at Timeout.<anonymous> (/.../dist/server.js:183290:4)
    at ZoneDelegate.module.exports.ZoneDelegate.invokeTask (/.../dist/server.js:577:31)
    at Zone.module.exports.Zone.runTask (/.../dist/server.js:349:47)
    at module.exports.ZoneTask.invokeTask (/.../dist/server.js:652:34)
    at Timeout.ZoneTask.invoke (/.../dist/server.js:641:48)
    at Timeout.timer [as _onTimeout] (/.../dist/server.js:2386:29)
    at listOnTimeout (internal/timers.js:531:17)
    at processTimers (internal/timers.js:475:7)
```

This is because during the registration of listeners, the reference is lost. Binding to window corrects this but introduces another issue where the Date method of the window is also lost and this throws as well. Passing the Date as a reference also corrects this.