### PR TITLE
Move TS to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "jquery-deparam": "^0.5.3",
     "picturefill": "^3.0.3",
     "qunitjs": "^2.4.1",
-    "respimage": "^1.4.2"
+    "respimage": "^1.4.2",
+		"typescript": "^4.1.5"
   },
   "npmName": "lazysizes",
   "npmFileMap": [
@@ -62,8 +63,5 @@
     "imager.js",
     "picturefill",
     "component"
-  ],
-  "dependencies": {
-    "typescript": "^4.1.5"
-  }
+  ]
 }


### PR DESCRIPTION
I don't see TS used during runtime so it can probably be a devDependency.

It was added in 9253212d67383a02be90f65d44d0b1da4b050a70 

See also https://packagephobia.com/result?p=lazysizes