### PR TITLE
Replace transition with css animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,14 +274,14 @@ lazysizes adds the class ``lazyloading`` while the images are loading and the cl
 /* fade image in after load */
 .lazyload,
 .lazyloading {
-  opacity: 0;
+	opacity: 0;
 }
 .lazyloaded {
-  animation: lazyFadeIn linear 0.1s;
+	animation: lazyFadeIn linear .3s;
 }
 @keyframes lazyFadeIn {
-  0% {opacity:0;}
-  100% {opacity:1;}
+	0% {opacity:0;}
+	100% {opacity:1;}
 }
 ```
 
@@ -292,14 +292,15 @@ lazysizes adds the class ``lazyloading`` while the images are loading and the cl
 	opacity: 0;
 }
 .lazyloading {
-  background: #f7f7f7 url(loader.gif) no-repeat center;
+	opacity: 1;
+	background: #f7f7f7 url(loader.gif) no-repeat center;
 }
 .lazyloaded {
-  animation: lazyFadeIn linear 0.1s;
+	animation: lazyFadeIn linear .3s;
 }
 @keyframes lazyFadeIn {
-  0% {opacity:0;}
-  100% {opacity:1;}
+	0% {opacity:0;}
+	100% {opacity:1;}
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -288,19 +288,19 @@ lazysizes adds the class ``lazyloading`` while the images are loading and the cl
 ```css
 /* fade image in while loading and show a spinner as background image (good for progressive images) */
 
-.lazyload {
-	opacity: 0;
+[data-src] {
+	filter: opacity(0);
 }
 .lazyloading {
-	opacity: 1;
+	filter: opacity(1);
 	background: #f7f7f7 url(loader.gif) no-repeat center;
 }
 .lazyloaded {
 	animation: lazyFadeIn linear .3s;
 }
 @keyframes lazyFadeIn {
-	0% {opacity:0;}
-	100% {opacity:1;}
+	0% {filter: opacity(0);}
+	100% {filter: opacity(1);}
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -274,11 +274,14 @@ lazysizes adds the class ``lazyloading`` while the images are loading and the cl
 /* fade image in after load */
 .lazyload,
 .lazyloading {
-	opacity: 0;
+  opacity: 0;
 }
 .lazyloaded {
-	opacity: 1;
-	transition: opacity 300ms;
+  animation: lazyFadeIn linear 0.1s;
+}
+@keyframes lazyFadeIn {
+  0% {opacity:0;}
+  100% {opacity:1;}
 }
 ```
 
@@ -288,11 +291,15 @@ lazysizes adds the class ``lazyloading`` while the images are loading and the cl
 .lazyload {
 	opacity: 0;
 }
-
 .lazyloading {
-	opacity: 1;
-	transition: opacity 300ms;
-	background: #f7f7f7 url(loader.gif) no-repeat center;
+  background: #f7f7f7 url(loader.gif) no-repeat center;
+}
+.lazyloaded {
+  animation: lazyFadeIn linear 0.1s;
+}
+@keyframes lazyFadeIn {
+  0% {opacity:0;}
+  100% {opacity:1;}
 }
 ```
 


### PR DESCRIPTION
This would solve a problem that can happen, especially if the images already have a transition effect applied. With animation the style is applied in a specific time frame without interfering with the css style. 

it's a small modification I know, but it can make everything more beautiful (or less glitchy). Thanks for your script it's very useful to me!