### PR TITLE
Fixing embed video autoplay fix + video size flexibility

### DIFF
--- a/plugins/video-embed/ls.video-embed.js
+++ b/plugins/video-embed/ls.video-embed.js
@@ -80,7 +80,7 @@
 		e.preventDefault();
 
 		elem.innerHTML = '<iframe src="' + (vimeoIframe.replace(regId, id)) + vimeoParams +'" ' +
-			'frameborder="0" allowfullscreen="" width="640" height="390"></iframe>'
+			'frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" width="100%" height="100%"></iframe>'
 		;
 
 	}
@@ -110,7 +110,7 @@
 		e.preventDefault();
 
 		elem.innerHTML = '<iframe src="' + (youtubeIframe.replace(regId, id)) + youtubeParams +'" ' +
-			'frameborder="0" allowfullscreen="" width="640" height="390"></iframe>'
+			'frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" width="100%" height="100%"></iframe>'
 		;
 	}
 


### PR DESCRIPTION
**The issues:**
- Currently, embed lazy-load videos are not auto-playing on the Chrome browser since 2018 when [Autoplay policies have changed](https://developers.google.com/web/updates/2017/09/autoplay-policy-changes).
Now you have to make sure to add `allow="autoplay"` into `iframe` tag to enable this.
- Setting `width` and `height` to 100% gives more control over `iframe`'s sizes, by changing its container's properties.