### PR TITLE
[fix] use `window.MutationObserver` since that's ensured by the conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 5.3.2
+- Fix: only use `window.MutationObserver` since that is what we ensure in the guard statements.
+
 ### 5.3.1
 - Added basic Typescript support
 

--- a/src/lazysizes-core.js
+++ b/src/lazysizes-core.js
@@ -665,7 +665,7 @@ function l(window, document, Date) { // Pass in the window Date function also fo
 				});
 
 				if(window.MutationObserver){
-					new MutationObserver( throttledCheckElements ).observe( docElem, {childList: true, subtree: true, attributes: true} );
+					new window.MutationObserver( throttledCheckElements ).observe( docElem, {childList: true, subtree: true, attributes: true} );
 				} else {
 					docElem[_addEventListener]('DOMNodeInserted', throttledCheckElements, true);
 					docElem[_addEventListener]('DOMAttrModified', throttledCheckElements, true);

--- a/src/lazysizes-intersection.js
+++ b/src/lazysizes-intersection.js
@@ -408,7 +408,7 @@
 					rootMargin: lazySizesCfg.expand + 'px ' + (lazySizesCfg.expand * lazySizesCfg.hFac) + 'px',
 				});
 
-				new MutationObserver( addElements ).observe( docElem, {childList: true, subtree: true, attributes: true} );
+				new window.MutationObserver( addElements ).observe( docElem, {childList: true, subtree: true, attributes: true} );
 
 				addElements();
 			},


### PR DESCRIPTION
I found this small issue in the source code, that is, in non-browser environments, we potentially make the wrong assumption about the global context. For example: in tests, or SSR we ensure that we have `window.MutationObserver` but we proceed to use `MutationObserver` without a prefix - the global defaults to `window` in a browser, but it is not `window` in tests.

I wouldn't want to go into detail about why/how this module is triggered in our tests, I'm just fixing some test cases in our organization, and I can see a lot of errors spewed in the logs due to this above, and I found the fix might be a reasonable small addition.  