### PR TITLE
Created new data attribute that can be used to add alt tags to img

### DIFF
--- a/plugins/bgset/ls.bgset.js
+++ b/plugins/bgset/ls.bgset.js
@@ -59,6 +59,7 @@
 		var picture = document.createElement('picture');
 		var sizes = elem.getAttribute(lazySizesCfg.sizesAttr);
 		var ratio = elem.getAttribute('data-ratio');
+		var alt = elem.getAttribute('data-alt');
 		var optimumx = elem.getAttribute('data-optimumx');
 
 		if(elem._lazybgset && elem._lazybgset.parentNode == elem){
@@ -113,6 +114,9 @@
 		}
 		if(ratio) {
 			img.setAttribute('data-ratio', ratio);
+		}
+		if(alt) {
+			img.alt = alt;
 		}
 
 		picture.appendChild(img);


### PR DESCRIPTION
Recently, I have been using the bgset plugin within a project and had some complaints off a client about issues with SEO since the created img tag does not have an alt tag set

I have updated the js code to check for a `data-alt` attribute and then add this to the created img tag