### PR TITLE
Fix lazy loaded video autoplay

### DIFF
--- a/plugins/unveilhooks/ls.unveilhooks.js
+++ b/plugins/unveilhooks/ls.unveilhooks.js
@@ -90,7 +90,10 @@ For background images, use data-bg attribute:
 				if (target.getAttribute('data-autoplay') != null) {
 					if (target.getAttribute('data-expand') && !target.autoplay) {
 						try {
-							target.play();
+							target.load();
+							setTimeout(function () {
+								target.play();
+							}, 0);
 						} catch (er) {}
 					} else {
 						requestAnimationFrame(function () {


### PR DESCRIPTION
Autoplaying lazy loaded video with the [markup](https://github.com/aFarkas/lazysizes/issues/697#issuecomment-540427648) suggested by @aFarkas  fails with an error https://developer.chrome.com/blog/play-request-was-interrupted/

This fix triggers video loading first and then plays it. It seems to work. I'm not sure if there is more elegant solution to this problem.